### PR TITLE
Fix host-only IP for VirtualBox 7.x compatibility

### DIFF
--- a/lesson-1-introduction-to-microservices-security/exercises/starter/Vagrantfile
+++ b/lesson-1-introduction-to-microservices-security/exercises/starter/Vagrantfile
@@ -9,7 +9,10 @@ Vagrant.configure("2") do |config|
   config.vm.boot_timeout = 900
 
   # st the static IP for the vagrant box
-  config.vm.network "private_network", ip: "192.168.50.4"
+  # Use 192.168.56.0/21 — the default host-only range allowed by VirtualBox 7.x.
+  # Older 6.1.x accepts it too, so this works on both Vagrant 2.2.10+/VBox 6.1.x
+  # and Vagrant 2.4.x/VBox 7.1.x without editing /etc/vbox/networks.conf.
+  config.vm.network "private_network", ip: "192.168.56.4"
   
   # consifure the parameters for VirtualBox provider
   config.vm.provider "virtualbox" do |vb|

--- a/lesson-3-docker-attack-surface-analysis-and-hardening/exercises/starter/Vagrantfile
+++ b/lesson-3-docker-attack-surface-analysis-and-hardening/exercises/starter/Vagrantfile
@@ -8,7 +8,10 @@ Vagrant.configure("2") do |config|
   config.vm.boot_timeout = 900
 
   # st the static IP for the vagrant box
-  config.vm.network "private_network", ip: "192.168.50.4"
+  # Use 192.168.56.0/21 — the default host-only range allowed by VirtualBox 7.x.
+  # Older 6.1.x accepts it too, so this works on both Vagrant 2.2.10+/VBox 6.1.x
+  # and Vagrant 2.4.x/VBox 7.1.x without editing /etc/vbox/networks.conf.
+  config.vm.network "private_network", ip: "192.168.56.4"
   
   # consifure the parameters for VirtualBox provider
   config.vm.provider "virtualbox" do |vb|

--- a/lesson-4-kubernetes-attack-surface-and-hardening/exercises/starter/Vagrantfile
+++ b/lesson-4-kubernetes-attack-surface-and-hardening/exercises/starter/Vagrantfile
@@ -22,7 +22,10 @@ Vagrant.configure("2") do |config|
       node.vm.hostname = "node#{i}"
 
       # set the static IP for the vagrant box
-      node.vm.network "private_network", ip: "192.168.50.10#{i}"
+      # Use 192.168.56.0/21 — the default host-only range allowed by VirtualBox 7.x.
+      # Older 6.1.x accepts it too, so this works on both Vagrant 2.2.10+/VBox 6.1.x
+      # and Vagrant 2.4.x/VBox 7.1.x without editing /etc/vbox/networks.conf.
+      node.vm.network "private_network", ip: "192.168.56.10#{i}"
       # configure the parameters for VirtualBox provider
       node.vm.provider "virtualbox" do |v|
         v.name = "node#{i}"

--- a/lesson-6-runtime-monitoring-and-incident-response/exercises/starter/Vagrantfile
+++ b/lesson-6-runtime-monitoring-and-incident-response/exercises/starter/Vagrantfile
@@ -30,7 +30,10 @@ Vagrant.configure("2") do |config|
       # config.vm.network "forwarded_port", guest: 3000, host: 3000
 
       # set the static IP for the vagrant box
-      node.vm.network "private_network", ip: "192.168.50.10#{i}"
+      # Use 192.168.56.0/21 — the default host-only range allowed by VirtualBox 7.x.
+      # Older 6.1.x accepts it too, so this works on both Vagrant 2.2.10+/VBox 6.1.x
+      # and Vagrant 2.4.x/VBox 7.1.x without editing /etc/vbox/networks.conf.
+      node.vm.network "private_network", ip: "192.168.56.10#{i}"
       # configure the parameters for VirtualBox provider
       node.vm.provider "virtualbox" do |v|
         v.name = "node#{i}"


### PR DESCRIPTION
## Summary
All four exercise Vagrantfiles in this repo configure the host-only private network in the `192.168.50.0/24` range:

| Lesson | File | Original IP |
|---|---|---|
| 1 | `lesson-1-introduction-to-microservices-security/exercises/starter/Vagrantfile` | `192.168.50.4` |
| 3 | `lesson-3-docker-attack-surface-analysis-and-hardening/exercises/starter/Vagrantfile` | `192.168.50.4` |
| 4 | `lesson-4-kubernetes-attack-surface-and-hardening/exercises/starter/Vagrantfile` | `192.168.50.10#{i}` (NodeCount=2) |
| 6 | `lesson-6-runtime-monitoring-and-incident-response/exercises/starter/Vagrantfile` | `192.168.50.10#{i}` (NodeCount=1) |

VirtualBox 7.0+ enforces `/etc/vbox/networks.conf` and by default only permits host-only IPs in `192.168.56.0/21`. On Vagrant 2.4.x + VirtualBox 7.1.x, `vagrant up` therefore fails with:

> The IP address configured for the host-only network is not within the allowed ranges.

This PR moves each IP to the equivalent address in `192.168.56.0/21`:

| Lesson | New IP |
|---|---|
| 1 | `192.168.56.4` |
| 3 | `192.168.56.4` |
| 4 | `192.168.56.10#{i}` (preserves per-node host-id pattern) |
| 6 | `192.168.56.10#{i}` (preserves per-node host-id pattern) |

The new addresses are inside the default-allowed range for VirtualBox 7.x **and** are also accepted by VirtualBox 6.1.x — so the existing Vagrant 2.2.10+ / VBox 6.1.x setup keeps working without any change to the host configuration.

The box image (`opensuse/Leap-15.6.x86_64` `15.6.13.356`) is already current across all four files, so no box bump is needed here.

This mirrors the same fix applied in:
- [udacity/nd064_course_1#126](https://github.com/udacity/nd064_course_1/pull/126)
- [udacity/CNAND_nd064_C4_Observability_Starter_Files#32](https://github.com/udacity/CNAND_nd064_C4_Observability_Starter_Files/pull/32)
- [udacity/nd064-c3-microservices-security-project-starter#14](https://github.com/udacity/nd064-c3-microservices-security-project-starter/pull/14)

## Test plan
- [ ] `vagrant up` succeeds for each lesson's Vagrantfile on Vagrant 2.2.10+ with VirtualBox 6.1.x (no `/etc/vbox/networks.conf` edits).
- [ ] `vagrant up` succeeds for each lesson's Vagrantfile on Vagrant 2.4.2+ with VirtualBox 7.1.x (no `/etc/vbox/networks.conf` edits).
- [ ] Lesson 4 brings up both `node1` (192.168.56.101) and `node2` (192.168.56.102) and they can reach each other on the host-only network.
- [ ] Lesson 6 brings up `node1` (192.168.56.101) and the public-network bridge / forwarded-port comments still behave as before.